### PR TITLE
(Feature) Enable multiple mastodon accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 TESTS_INIT=tests/minimal_init.lua
 TESTS_DIR=tests/
 
+.EXPORT_ALL_VARIABLES:
+
+PROJECT_ENV = test
+
 .PHONY: test
 
 test:

--- a/lua/mastodon.lua
+++ b/lua/mastodon.lua
@@ -29,4 +29,12 @@ M.toot_message = function(opts)
   commands.toot_message(message)
 end
 
+M.add_account = function()
+  local result = commands.add_account()
+  if result ~= true then
+    vim.notify("Successfully added your account!")
+  else
+    vim.notify("Failed to adding your account", vim.log.levels.ERROR)
+  end
+end
 return M

--- a/lua/mastodon.lua
+++ b/lua/mastodon.lua
@@ -37,4 +37,13 @@ M.add_account = function()
     vim.notify("Failed to adding your account", vim.log.levels.ERROR)
   end
 end
+
+M.select_account = function()
+  local account = commands.select_account()
+  if account ~= nil then
+  else
+    vim.notify("You need to add account using :MastodonAddAccount", vim.log.levels.ERROR)
+  end
+end
+
 return M

--- a/lua/mastodon/commands.lua
+++ b/lua/mastodon/commands.lua
@@ -45,4 +45,47 @@ M.toot_message = function(message)
   return response
 end
 
+M.add_account = function()
+  local cmd = "curl"
+
+  instance_url = vim.fn.input({ prompt = 'Enter your fediverse instance url (ex: https://social.silicon.moe): '})
+  access_token = vim.fn.input({ prompt = 'Enter your access_token : ' })
+
+  cmd = cmd .. " " .. "'" .. instance_url .. "/api/v1/apps/verify_credentials'"
+  cmd = cmd .. " -s"
+  cmd = cmd .. " -X " .. "GET"
+  cmd = cmd .. " -H " .. "'Accept: application/json'"
+  cmd = cmd .. " -H " .. "'Content-Type: application/json'"
+  cmd = cmd .. " -H " .. "'Authorization: Bearer " .. access_token .. "'"
+
+  local response = utils.execute_curl(cmd)
+  local app_name = utils.parse_json(response)["name"]
+
+  if app_name ~= nil then
+    cmd = "curl"
+
+    cmd = cmd .. " " .. "'" .. instance_url .. "/api/v1/accounts/verify_credentials'"
+    cmd = cmd .. " -s"
+    cmd = cmd .. " -X " .. "GET"
+    cmd = cmd .. " -H " .. "'Accept: application/json'"
+    cmd = cmd .. " -H " .. "'Content-Type: application/json'"
+    cmd = cmd .. " -H " .. "'Authorization: Bearer " .. access_token .. "'"
+
+    response = utils.execute_curl(cmd)
+    json = utils.parse_json(response)
+    local username = json['display_name'] .. "(@" .. json['username'] .. ")"
+    local description = json['source']['note']
+
+    db_client:add_account({
+      instance_url = instance_url,
+      access_token = access_token,
+      username     = username,
+      description  = description
+    })
+
+    return false
+  else
+    return true
+  end
+end
 return M

--- a/lua/mastodon/db_client.lua
+++ b/lua/mastodon/db_client.lua
@@ -1,0 +1,91 @@
+local vim = vim
+
+local has_sqlite, sqlite = pcall(require, "sqlite")
+if not has_sqlite then
+  error("This plugin requires sqlite.lua (https://github.com/kkharji/sqlite.lua) " .. tostring(sqlite))
+end
+
+local db_table = {}
+db_table.mastodon_accounts = "mastodon_accounts"
+
+
+local M = {}
+
+
+function M:new()
+  local o = {}
+  setmetatable(o, self)
+  self.db = nil
+  return o
+end
+
+function M:reset_database()
+  self:bootstrap(nil)
+  return self.db:with_open(function(db)
+    return db:delete("mastodon_accounts")
+  end)
+end
+
+function M:bootstrap(db_root)
+  if self.db then return end
+
+  local project_env = os.getenv("PROJECT_ENV") or "production"
+  db_root = db_root or vim.fn.stdpath('data')
+  local db_name = 'mastodon_accounts'
+  if project_env == 'test' then
+    db_name = db_name .. '_test'
+  end
+
+  local db_filename = db_root .. "/" .. db_name .. ".sqlite3"
+  self.db = sqlite:open(db_filename)
+
+  if not self.db then
+    vim.notify("Mastodon.nvim: error in opening DB", vim.log.levels.ERROR)
+    return
+  end
+
+  local first_run = false
+
+  if not self.db:exists(db_table.mastodon_accounts) then
+    first_run = true
+    self.db:create(db_table.mastodon_accounts, {
+      id           = {"INTEGER", "PRIMARY", "KEY"},
+      instance_url = {"TEXT"},
+      access_token = {"TEXT"},
+      username     = {"TEXT"},
+      description  = {"TEXT"},
+      is_active    = {"BOOLEAN"},
+    })
+  end
+
+  self.db:close()
+  return first_run
+end
+
+function M:get_all_accounts()
+  self:bootstrap(nil)
+  return self.db:with_open(function(db)
+    return db:select("mastodon_accounts", {})
+  end)
+end
+
+function M:get_active_account()
+  return self:select_account({ is_active = true })
+end
+
+function M:add_account(params)
+  self:bootstrap(nil)
+  return self.db:with_open(function(db)
+    return db:insert("mastodon_accounts", params)
+  end)
+end
+
+function M:select_account(params)
+  self:bootstrap(nil)
+  return self.db:with_open(function(db)
+    return db:select("mastodon_accounts", params)
+  end)
+end
+
+
+return M

--- a/lua/mastodon/db_client.lua
+++ b/lua/mastodon/db_client.lua
@@ -73,6 +73,20 @@ function M:get_active_account()
   return self:select_account({ is_active = true })
 end
 
+function M:set_active_account(params)
+  self:bootstrap(nil)
+  return self.db:with_open(function(db)
+    db:update("mastodon_accounts", {
+      set = { is_active = false}
+    })
+    db:update("mastodon_accounts", {
+      where = params,
+      set = { is_active = true }
+    })
+    return true
+  end)
+end
+
 function M:add_account(params)
   self:bootstrap(nil)
   return self.db:with_open(function(db)

--- a/plugin/mastodon.lua
+++ b/plugin/mastodon.lua
@@ -1,2 +1,3 @@
 vim.api.nvim_create_user_command("MyFirstFunction", require("mastodon").greeting, {})
-vim.api.nvim_create_user_command("TootMessage", require("mastodon").toot_message, { nargs = 1 })
+vim.api.nvim_create_user_command("MastodonTootMessage", require("mastodon").toot_message, { nargs = 1 })
+vim.api.nvim_create_user_command("MastodonAddAccount", require("mastodon").add_account, {})

--- a/plugin/mastodon.lua
+++ b/plugin/mastodon.lua
@@ -1,3 +1,4 @@
 vim.api.nvim_create_user_command("MyFirstFunction", require("mastodon").greeting, {})
 vim.api.nvim_create_user_command("MastodonTootMessage", require("mastodon").toot_message, { nargs = 1 })
 vim.api.nvim_create_user_command("MastodonAddAccount", require("mastodon").add_account, {})
+vim.api.nvim_create_user_command("MastodonSelectAccount", require("mastodon").select_account, {})

--- a/tests/mastodon/db_client_spec.lua
+++ b/tests/mastodon/db_client_spec.lua
@@ -1,0 +1,36 @@
+
+local db_client = require("mastodon.db_client")
+
+describe("setup", function()
+  before_each(function()
+    db_client:bootstrap()
+    db_client:reset_database()
+  end)
+
+  it("Added accounts can be displayed in select view", function()
+    db_client:add_account({
+      username = 'hello',
+      access_token = 'hello',
+      instance_url = 'hello',
+      description = 'world',
+      is_active = false,
+    })
+    db_client:add_account({
+      username = 'hello',
+      access_token = 'hello',
+      instance_url = 'hello',
+      description = 'world',
+      is_active = false,
+    })
+    db_client:add_account({
+      username = 'hello',
+      access_token = 'hello',
+      instance_url = 'hello',
+      description = 'world',
+      is_active = false,
+    })
+
+    local accounts = db_client:get_all_accounts()
+    assert(table.getn(accounts) == 3)
+  end)
+end)


### PR DESCRIPTION
closes: kode-team/mastodon.nvim#3 

Thanks to kkharji/sqlite.lua, we can manage multiple mastodon accounts with ease.

# Commands 

* `:TootMessage` -> `:MastodonTootMessage` (renamed)
  * Before using this command, you need to activate your account by `:MastodonSelectAccount` 
* `:MastodonAddAccount` (new)
  * Input your account's instance url and access_token, then account information will be added to database
  * Then, you can select account by `:MastodonSelectAccount` command
* `:MastodonSelectAccount` (new)
  * Before using this command, you need to add your account by `:MastodonAddAccount`