### PR TITLE
Support timeline navigation

### DIFF
--- a/lua/mastodon/api_client.lua
+++ b/lua/mastodon/api_client.lua
@@ -51,9 +51,22 @@ M.get_status = function(status_id)
   return status
 end
 
-M.fetch_home_timeline = function()
+M.fetch_home_timeline = function(params)
   local active_accounts = db_client:get_active_account()
   local active_account = active_accounts[1]
+  local query = {}
+
+  if params.since_id ~= nil then
+    query.since_id = params.since_id
+  end
+
+  if params.max_id ~= nil then
+    query.max_id = params.max_id
+  end
+
+  if params.min_id ~= nil then
+    query.min_id = params.min_id
+  end
 
   local access_token = active_account.access_token
   local instance_url = active_account.instance_url
@@ -61,6 +74,7 @@ M.fetch_home_timeline = function()
   local url = instance_url .. "/api/v1/timelines/home"
 
   local res = curl.get(url, {
+    query = query,
     headers = {
       accept = "application/json",
       content_type = "application/json",

--- a/lua/mastodon/commands.lua
+++ b/lua/mastodon/commands.lua
@@ -133,8 +133,6 @@ M.fetch_home_timeline = function()
       vim.b[bufnr].min_status_id = min_status_id
     end
   end
-
-  vim.api.nvim_win_set_cursor(0, {1, 0})
 end
 
 M.fetch_bookmarks = function()
@@ -158,8 +156,6 @@ M.fetch_bookmarks = function()
 
   bufnr = vim.api.nvim_get_current_buf()
   renderer.render_bookmarks(bufnr, win, statuses)
-
-  vim.api.nvim_win_set_cursor(0, {1, 0})
 end
 
 M.fetch_favourites = function()
@@ -183,8 +179,6 @@ M.fetch_favourites = function()
 
   bufnr = vim.api.nvim_get_current_buf()
   renderer.render_favourites(bufnr, win, statuses)
-
-  vim.api.nvim_win_set_cursor(0, {1, 0})
 end
 
 M.fetch_replies = function()
@@ -208,8 +202,6 @@ M.fetch_replies = function()
 
   bufnr = vim.api.nvim_get_current_buf()
   renderer.render_replies(bufnr, win, statuses)
-
-  vim.api.nvim_win_set_cursor(0, {1, 0})
 end
 
 M.reload_statuses = function()
@@ -243,8 +235,6 @@ M.reload_statuses = function()
         vim.b[bufnr].min_status_id = min_status_id
       end
     end
-
-    vim.api.nvim_win_set_cursor(0, {1, 0})
   elseif string.find(buf_name, "Mastodon Bookmark") then
     local new_buf = vim.api.nvim_create_buf(true, true)
     vim.api.nvim_win_set_buf(win, new_buf)
@@ -253,8 +243,6 @@ M.reload_statuses = function()
 
     local statuses = api_client.fetch_bookmarks()
     renderer.render_bookmarks(bufnr, win, statuses)
-
-    vim.api.nvim_win_set_cursor(0, {1, 0})
   elseif string.find(buf_name, "Mastodon Favourites") then
     local new_buf = vim.api.nvim_create_buf(true, true)
     vim.api.nvim_win_set_buf(win, new_buf)
@@ -263,8 +251,6 @@ M.reload_statuses = function()
 
     local statuses = api_client.fetch_favourites()
     renderer.render_favourites(bufnr, win, statuses)
-
-    vim.api.nvim_win_set_cursor(0, {1, 0})
   elseif string.find(buf_name, "Mastodon Replies") then
     local new_buf = vim.api.nvim_create_buf(true, true)
     vim.api.nvim_win_set_buf(win, new_buf)
@@ -273,8 +259,6 @@ M.reload_statuses = function()
 
     local statuses = api_client.fetch_replies()
     renderer.render_favourites(bufnr, win, statuses)
-
-    vim.api.nvim_win_set_cursor(0, {1, 0})
   end
 end
 

--- a/lua/mastodon/commands.lua
+++ b/lua/mastodon/commands.lua
@@ -293,7 +293,7 @@ M.fetch_older_statuses = function()
     render_statuses = renderer.render_home_timeline
   end
 
-  if string.find(buf_name, "Mastodon") then
+  if string.find(buf_name, "Mastodon Home") then
     local statuses = fetch_statuses({ max_id = min_status_id })
     if #statuses > 0 then
       min_status_id = statuses[#statuses]["id"]
@@ -321,7 +321,7 @@ M.fetch_newer_statuses = function()
     render_statuses = renderer.render_home_timeline
   end
 
-  if string.find(buf_name, "Mastodon") then
+  if string.find(buf_name, "Mastodon Home") then
     local statuses = fetch_statuses({ min_id = max_status_id })
     if #statuses > 0 then
       max_status_id = statuses[1]["id"]

--- a/lua/mastodon/renderer.lua
+++ b/lua/mastodon/renderer.lua
@@ -244,7 +244,7 @@ local function prepare_statuses(statuses, width)
   }
 end
 
-local function render_statuses(bufnr, win, statuses, buf_name)
+local function render_statuses(bufnr, win, statuses, buf_name, mode)
   local namespaces = vim.api.nvim_get_namespaces()
   local mastodon_ns = namespaces['MastodonNS']
 
@@ -254,36 +254,60 @@ local function render_statuses(bufnr, win, statuses, buf_name)
   local line_numbers = result.line_numbers
   local metadata = result.metadata
 
+  local offset = 0
   vim.api.nvim_buf_set_name(bufnr, buf_name)
   vim.api.nvim_buf_set_option(bufnr, "filetype", "mastodon")
-  vim.api.nvim_buf_set_lines(0, 0, 0, 'true', lines)
+  if mode == "prepend" then
+    offset = 0
+    vim.api.nvim_buf_set_lines(bufnr, 0, 0, 'true', lines)
+  elseif mode == "append" then
+    offset = vim.api.nvim_buf_line_count(bufnr)
+    vim.api.nvim_buf_set_lines(bufnr, -1, -1, 'true', lines)
+  end
+
   vim.api.nvim_win_set_hl_ns(win, mastodon_ns)
 
   for _, line_number in ipairs(line_numbers) do
-    vim.api.nvim_buf_add_highlight(bufnr, mastodon_ns, "MastodonHandle", line_number, 0, -1)
+    vim.api.nvim_buf_add_highlight(bufnr, mastodon_ns, "MastodonHandle", offset + line_number, 0, -1)
   end
 
   for _, metadata_for_line in ipairs(metadata) do
-    vim.api.nvim_buf_set_extmark(bufnr, mastodon_ns, metadata_for_line.line_number, 0, {
+    vim.api.nvim_buf_set_extmark(bufnr, mastodon_ns, offset + metadata_for_line.line_number, 0, {
       virt_text = {{metadata_for_line.data, "Whitespace"}},
     })
   end
 end
 
-M.render_home_timeline = function(bufnr, win, statuses)
-  render_statuses(bufnr, win, statuses, "Mastodon Home")
+M.render_home_timeline = function(bufnr, win, statuses, options)
+  local mode = "prepend"
+  if options ~= nil then
+    mode = options.mode
+  end
+  render_statuses(bufnr, win, statuses, "Mastodon Home", mode)
 end
 
-M.render_bookmarks = function(bufnr, win, statuses)
-  render_statuses(bufnr, win, statuses, "Mastodon Bookmark")
+M.render_bookmarks = function(bufnr, win, statuses, options)
+  local mode = "prepend"
+  if options ~= nil then
+    mode = options.mode
+  end
+  render_statuses(bufnr, win, statuses, "Mastodon Bookmark", mode)
 end
 
-M.render_favourites = function(bufnr, win, statuses)
-  render_statuses(bufnr, win, statuses, "Mastodon Favourites")
+M.render_favourites = function(bufnr, win, statuses, options)
+  local mode = "prepend"
+  if options ~= nil then
+    mode = options.mode
+  end
+  render_statuses(bufnr, win, statuses, "Mastodon Favourites", mode)
 end
 
-M.render_replies = function(bufnr, win, statuses)
-  render_statuses(bufnr, win, statuses, "Mastodon Replies")
+M.render_replies = function(bufnr, win, statuses, options)
+  local mode = "prepend"
+  if options ~= nil then
+    mode = options.mode
+  end
+  render_statuses(bufnr, win, statuses, "Mastodon Replies", mode)
 end
 
 M.flatten_nodes = flatten_nodes

--- a/lua/mastodon/renderer.lua
+++ b/lua/mastodon/renderer.lua
@@ -244,7 +244,7 @@ local function prepare_statuses(statuses, width)
   }
 end
 
-M.render_home_timeline = function(bufnr, win, statuses)
+local function render_statuses(bufnr, win, statuses, buf_name)
   local namespaces = vim.api.nvim_get_namespaces()
   local mastodon_ns = namespaces['MastodonNS']
 
@@ -254,7 +254,7 @@ M.render_home_timeline = function(bufnr, win, statuses)
   local line_numbers = result.line_numbers
   local metadata = result.metadata
 
-  vim.api.nvim_buf_set_name(bufnr, "Mastodon Home")
+  vim.api.nvim_buf_set_name(bufnr, buf_name)
   vim.api.nvim_buf_set_option(bufnr, "filetype", "mastodon")
   vim.api.nvim_buf_set_lines(0, 0, 0, 'true', lines)
   vim.api.nvim_win_set_hl_ns(win, mastodon_ns)
@@ -268,84 +268,22 @@ M.render_home_timeline = function(bufnr, win, statuses)
       virt_text = {{metadata_for_line.data, "Whitespace"}},
     })
   end
+end
+
+M.render_home_timeline = function(bufnr, win, statuses)
+  render_statuses(bufnr, win, statuses, "Mastodon Home")
 end
 
 M.render_bookmarks = function(bufnr, win, statuses)
-  local namespaces = vim.api.nvim_get_namespaces()
-  local mastodon_ns = namespaces['MastodonNS']
-
-  local width = vim.api.nvim_win_get_width(win)
-  local result = prepare_statuses(statuses, width)
-  local lines = result.lines
-  local line_numbers = result.line_numbers
-  local metadata = result.metadata
-
-  vim.api.nvim_buf_set_name(bufnr, "Mastodon Bookmark")
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "mastodon")
-  vim.api.nvim_buf_set_lines(0, 0, 0, 'true', lines)
-  vim.api.nvim_win_set_hl_ns(win, mastodon_ns)
-
-  for _, line_number in ipairs(line_numbers) do
-    vim.api.nvim_buf_add_highlight(bufnr, mastodon_ns, "MastodonHandle", line_number, 0, -1)
-  end
-
-  for _, metadata_for_line in ipairs(metadata) do
-    vim.api.nvim_buf_set_extmark(bufnr, mastodon_ns, metadata_for_line.line_number, 0, {
-      virt_text = {{metadata_for_line.data, "Whitespace"}},
-    })
-  end
+  render_statuses(bufnr, win, statuses, "Mastodon Bookmark")
 end
 
 M.render_favourites = function(bufnr, win, statuses)
-  local namespaces = vim.api.nvim_get_namespaces()
-  local mastodon_ns = namespaces['MastodonNS']
-
-  local width = vim.api.nvim_win_get_width(win)
-  local result = prepare_statuses(statuses, width)
-  local lines = result.lines
-  local line_numbers = result.line_numbers
-  local metadata = result.metadata
-
-  vim.api.nvim_buf_set_name(bufnr, "Mastodon Favourites")
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "mastodon")
-  vim.api.nvim_buf_set_lines(0, 0, 0, 'true', lines)
-  vim.api.nvim_win_set_hl_ns(win, mastodon_ns)
-
-  for _, line_number in ipairs(line_numbers) do
-    vim.api.nvim_buf_add_highlight(bufnr, mastodon_ns, "MastodonHandle", line_number, 0, -1)
-  end
-
-  for _, metadata_for_line in ipairs(metadata) do
-    vim.api.nvim_buf_set_extmark(bufnr, mastodon_ns, metadata_for_line.line_number, 0, {
-      virt_text = {{metadata_for_line.data, "Whitespace"}},
-    })
-  end
+  render_statuses(bufnr, win, statuses, "Mastodon Favourites")
 end
 
 M.render_replies = function(bufnr, win, statuses)
-  local namespaces = vim.api.nvim_get_namespaces()
-  local mastodon_ns = namespaces['MastodonNS']
-
-  local width = vim.api.nvim_win_get_width(win)
-  local result = prepare_statuses(statuses, width)
-  local lines = result.lines
-  local line_numbers = result.line_numbers
-  local metadata = result.metadata
-
-  vim.api.nvim_buf_set_name(bufnr, "Mastodon Replies")
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "mastodon")
-  vim.api.nvim_buf_set_lines(0, 0, 0, 'true', lines)
-  vim.api.nvim_win_set_hl_ns(win, mastodon_ns)
-
-  for _, line_number in ipairs(line_numbers) do
-    vim.api.nvim_buf_add_highlight(bufnr, mastodon_ns, "MastodonHandle", line_number, 0, -1)
-  end
-
-  for _, metadata_for_line in ipairs(metadata) do
-    vim.api.nvim_buf_set_extmark(bufnr, mastodon_ns, metadata_for_line.line_number, 0, {
-      virt_text = {{metadata_for_line.data, "Whitespace"}},
-    })
-  end
+  render_statuses(bufnr, win, statuses, "Mastodon Replies")
 end
 
 M.flatten_nodes = flatten_nodes

--- a/lua/mastodon/renderer.lua
+++ b/lua/mastodon/renderer.lua
@@ -276,6 +276,12 @@ local function render_statuses(bufnr, win, statuses, buf_name, mode)
       virt_text = {{metadata_for_line.data, "Whitespace"}},
     })
   end
+
+  if mode == "prepend" then
+    utils.scroll_to_top()
+  elseif mode == "append" then
+    utils.scroll_to_bottom()
+  end
 end
 
 M.render_home_timeline = function(bufnr, win, statuses, options)

--- a/lua/mastodon/utils.lua
+++ b/lua/mastodon/utils.lua
@@ -4,6 +4,15 @@ M.trim = function(s)
   return (string.gsub(s, "^%s*(.-)%s*$", "%1"))
 end
 
+M.scroll_to_top = function()
+  vim.api.nvim_win_set_cursor(0, {1, 0})
+end
+
+M.scroll_to_bottom = function()
+  local target = vim.api.nvim_buf_line_count(0)
+  vim.api.nvim_win_set_cursor(0, {target, 0})
+end
+
 M.execute_curl = function(curl_command)
   local handle = io.popen(curl_command, 'r')
   local response = handle:read("*a")

--- a/plugin/mastodon.lua
+++ b/plugin/mastodon.lua
@@ -21,6 +21,8 @@ vim.api.nvim_create_autocmd('FileType', {
     -- if keymap starts with `,m`,
     -- buffer-wide or system-wide commands should be called
     map('n', ',mr', ":lua require('mastodon').reload_statuses()<CR>", default_opts)
+    map('n', ',mk', ":lua require('mastodon.commands').fetch_newer_statuses()<CR>", default_opts)
+    map('n', ',mj', ":lua require('mastodon.commands').fetch_older_statuses()<CR>", default_opts)
 
     -- If keymap starts with `,t`
     -- status-wide commands should be called


### PR DESCRIPTION
This PR will include 

* Fetching statuses newer than `since_id` and prepending current MastodonBuffer
* Fetching statuses older than `max_id` and appending current MastodonBuffer

**UPD 230103**

Because of this, Timeline naviation will be only supported in Home Timeline

See https://docs.joinmastodon.org/api/guidelines/#pagination
Pagination using header will be continue in next release
