### PR TITLE
fix select account esc nil error

### DIFF
--- a/lua/mastodon/commands.lua
+++ b/lua/mastodon/commands.lua
@@ -83,12 +83,12 @@ M.select_account = function()
       return formatted_name .. account.username .. " / " .. account.instance_url
     end
   }, function(account)
-    local params = { id = account.id }
-    db_client:set_active_account(params)
-    vim.notify("Logged in to " .. account.username .. ' / ' .. account.instance_url)
-    selected_account = account
-
-    return account
+    if account ~= nil then
+      local params = { id = account.id }
+      db_client:set_active_account(params)
+      vim.notify("Logged in to " .. account.username .. ' / ' .. account.instance_url)
+      selected_account = account
+    end
   end)
 
   return selected_account


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46488521/209788526-39feded9-bb57-49b0-829f-0d840a3e7cbc.png)

According to [nvim lua ui docs](https://neovim.io/doc/user/lua.html#lua-ui), `{on_choice}` function receives argument in type (input|nil).
If user aborts ui using some keys like `<ESC>` it returns nil.
Thus handler for nil value is added.

Additionally, return value from `{on_choice}` have been removed because `{on_choice}` function returns nothing according to nvim docs.

**FYI. Error Message**
![image](https://user-images.githubusercontent.com/46488521/209789823-1fe100b9-00e5-4d84-b3cc-64c2dfb312df.png)
