### PR TITLE
Fix stylua in the default workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,10 +7,11 @@ jobs:
     name: stylua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: JohnnyMorganz/stylua-action@1.0.0
+      - uses: actions/checkout@v3
+      - uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
           args: --color always --check lua
 
   test:


### PR DESCRIPTION
This PR fixes the [workflow error with stylua](https://github.com/kode-team/mastodon.nvim/actions/runs/3798529845/jobs/6460302903).

- Updated GitHub Actions.
- Fixed stylua warnings in lua files.
