### PR TITLE
feature: added option to set toot visibility

### DIFF
--- a/lua/mastodon/api_client.lua
+++ b/lua/mastodon/api_client.lua
@@ -401,7 +401,7 @@ M.post_message = function(message)
       media_ids = {},
       sensitive = false,
       spoiler_text = "",
-      visibility = "unlisted",
+      visibility = vim.g.mastodon_toot_visibility or "unlisted",
       poll = nil,
       language = "ko",
     }),


### PR DESCRIPTION
This plugin is always convenient for us.

This PR allows you to set the public range of the toot by setting the variable `g:mastodon_toot_visibility`.
